### PR TITLE
Fix initialization and naming issues

### DIFF
--- a/Secalender/ContentView.swift
+++ b/Secalender/ContentView.swift
@@ -29,4 +29,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .environmentObject(FirebaseUserManager.shared)
 }

--- a/Secalender/Core/Authentication/AuthenticationView.swift
+++ b/Secalender/Core/Authentication/AuthenticationView.swift
@@ -11,7 +11,8 @@ import GoogleSignInSwift
 
 struct AuthenticationView: View {
     
-    @StateObject private var viewModle = AuthenticationViewModel()
+    // Use the correctly spelled property name
+    @StateObject private var viewModel = AuthenticationViewModel()
     @Binding var showSignInView: Bool
     
     var body: some View {
@@ -20,7 +21,7 @@ struct AuthenticationView: View {
             Button(action: {
                 Task {
                     do {
-                        try await viewModle.signInAnonymous()
+                        try await viewModel.signInAnonymous()
                         showSignInView = false
                     } catch {
                         print(error)
@@ -53,7 +54,7 @@ struct AuthenticationView: View {
             GoogleSignInButton(viewModel: GoogleSignInButtonViewModel(scheme: .light, style: .wide, state: .normal)){
                 Task {
                     do {
-                        try await viewModle.signInGoogle()
+                        try await viewModel.signInGoogle()
                         showSignInView = false
                     } catch {
                         print(error)
@@ -65,7 +66,7 @@ struct AuthenticationView: View {
             Button(action: {
                 Task {
                     do {
-                        try await viewModle.signInApple()
+                        try await viewModel.signInApple()
                         showSignInView = false
                     } catch {
                         print(error)

--- a/Secalender/SecalenderApp.swift
+++ b/Secalender/SecalenderApp.swift
@@ -11,11 +11,10 @@ import Firebase
 @main
 struct SecalenderApp: App {
 
+    // Firebase configuration is performed in AppDelegate.
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
-    init() {
-        // Configuration is handled in AppDelegate
-    }
+
     
     var body: some Scene {
         WindowGroup {

--- a/Secalender/SecalenderApp.swift
+++ b/Secalender/SecalenderApp.swift
@@ -14,8 +14,8 @@ struct SecalenderApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     init() {
-            FirebaseApp.configure()
-        }
+        // Configuration is handled in AppDelegate
+    }
     
     var body: some Scene {
         WindowGroup {

--- a/Secalender/Views/AddFriendView.swift
+++ b/Secalender/Views/AddFriendView.swift
@@ -105,5 +105,6 @@ struct FriendRequest: Identifiable {
 struct AddFriendView_Previews: PreviewProvider {
     static var previews: some View {
         AddFriendView()
+            .environmentObject(FirebaseUserManager.shared)
     }
 }

--- a/Secalender/Views/CalendarView.swift
+++ b/Secalender/Views/CalendarView.swift
@@ -166,5 +166,6 @@ private let monthFormatter: DateFormatter = {
 struct CalendarView_Previews: PreviewProvider {
     static var previews: some View {
         CalendarView()
+            .environmentObject(FirebaseUserManager.shared)
     }
 }

--- a/Secalender/Views/CommunityView.swift
+++ b/Secalender/Views/CommunityView.swift
@@ -91,5 +91,6 @@ struct CommunityView: View {
 struct CommunityView_Previews: PreviewProvider {
     static var previews: some View {
         CommunityView()
+            .environmentObject(FirebaseUserManager.shared)
     }
 }

--- a/Secalender/Views/EventCreateView.swift
+++ b/Secalender/Views/EventCreateView.swift
@@ -46,5 +46,6 @@ struct EventCreateView: View {
 struct EventCreateView_Previews: PreviewProvider {
     static var previews: some View {
         EventCreateView()
+            .environmentObject(FirebaseUserManager.shared)
     }
 }

--- a/Secalender/Views/MemberView.swift
+++ b/Secalender/Views/MemberView.swift
@@ -29,6 +29,7 @@ struct MemberView: View {
 struct MemberView_Previews: PreviewProvider {
     static var previews: some View {
         MemberView()
+            .environmentObject(FirebaseUserManager.shared)
     }
 }
 


### PR DESCRIPTION
## Summary
- fix typo for `viewModel` in `AuthenticationView`
- remove duplicate `FirebaseApp.configure` call in `SecalenderApp`

## Testing
- `find Secalender -name '*.swift' | xargs swiftc -parse`

------
https://chatgpt.com/codex/tasks/task_e_683fe3208ab08323a0529874ae535e42